### PR TITLE
fix isStickyFlatListHeader of undefined or null and fix types

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -3,13 +3,14 @@ import { FlatList, FlatListProps, ListRenderItem } from 'react-native'
 
 interface StickyHeaderFlatlistProps extends FlatListProps<any> {
   renderHeader: ListRenderItem<any>,
+  renderItem: ListRenderItem<any>,
   childrenKey?: string,
 }
 
 export default (props: StickyHeaderFlatlistProps) => {
 
-  let data = []
-  const indict = []
+  let data : any = [];
+  const indict : number[] = [];
 
   for (const i in props.data) {
     const row = props.data[i]
@@ -22,7 +23,7 @@ export default (props: StickyHeaderFlatlistProps) => {
     {...props}
     stickyHeaderIndices={indict}
     renderItem={(data) => 
-      data.item.isStickyFlatListHeader? 
+      data?.item?.isStickyFlatListHeader !== undefined && data?.item?.isStickyFlatListHeader !== null && data.item.isStickyFlatListHeader? 
       props.renderHeader(data):
       props.renderItem(data)
     }

--- a/index.tsx
+++ b/index.tsx
@@ -9,7 +9,7 @@ interface StickyHeaderFlatlistProps extends FlatListProps<any> {
 
 export default (props: StickyHeaderFlatlistProps) => {
 
-  let data : any = [];
+  let data : any[] = [];
   const indict : number[] = [];
 
   for (const i in props.data) {


### PR DESCRIPTION
PR fixes `TypeError: Cannot read property 'isStickyFlatListHeader' of undefined`